### PR TITLE
get and get-or-nil now support search of nested variables

### DIFF
--- a/botlang/environment/primitives/collections.py
+++ b/botlang/environment/primitives/collections.py
@@ -47,21 +47,37 @@ def dict_put_mutate(ordered_dict, key, value):
 
 def get_or_nil(data_struct, key):
     try:
-        return data_struct[key]
+        if isinstance(data_struct, dict):
+            return get_value_in_dict(data_struct, key)
+        else:
+            return data_struct[key]
     except KeyError:
         return Nil
     except IndexError:
         return Nil
 
-
 def dict_or_list_get(data_dict, key):
     try:
-        return data_dict[key]
+        if isinstance(data_dict, dict):
+            return get_value_in_dict(data_dict, key)
+        else:
+            return data_dict[key]
     except (KeyError, IndexError):
         return NativeException('collection',
                                ('The collection doest not '
                                 'have the key/index {}.'
                                 ).format(key))
+
+
+def get_value_in_dict(data, variable):
+    variable = str(variable)
+    access_order = variable.split('.')
+    actual_dict = data
+    for key in access_order:
+        actual_dict = actual_dict.get(key)
+        if actual_dict is None:
+            raise KeyError
+    return actual_dict
 
 
 def dict_remove_mutable(data_dict, key):

--- a/tests/primitives/test_collections.py
+++ b/tests/primitives/test_collections.py
@@ -1,0 +1,73 @@
+from unittest import TestCase
+
+from botlang import BotlangSystem
+from botlang.environment.primitives.collections import get_value_in_dict
+from botlang.evaluation.values import Nil
+
+
+class CollectionsTestCase(TestCase):
+
+    def test_get_value_in_dict(self):
+        the_dict = {'datos': {'mensajes': {'user': {'text': 'Jose'}}}}
+
+        result_value = get_value_in_dict(the_dict, 'datos.mensajes.user.text')
+        expected_value = 'Jose'
+        self.assertEqual(expected_value, result_value)
+
+        result_value = get_value_in_dict(the_dict, 'datos.mensajes')
+        expected_value = {'user': {'text': 'Jose'}}
+
+        self.assertEqual(expected_value, result_value)
+
+        result_value = get_value_in_dict({'dict': {}}, 'dict')
+        expected_value = {}
+
+        self.assertEqual(expected_value, result_value)
+
+        with self.assertRaises(KeyError):
+            get_value_in_dict(the_dict, 'texto')
+        with self.assertRaises(KeyError):
+            get_value_in_dict({}, 'texto')
+        with self.assertRaises(KeyError):
+            get_value_in_dict({}, '')
+
+    def test_get(self):
+        value = BotlangSystem.run("""
+            (define a_dict (make-dict))
+            (put! a_dict "uno" 1)
+            (get a_dict "uno")
+        """)
+        self.assertEqual(1, value)
+
+        value = BotlangSystem.run("""
+            (define a_dict (make-dict))
+            (define another_dict (make-dict))
+            (put! another_dict "uno" 1)
+            (put! a_dict "another_dict" another_dict)
+            (get a_dict "another_dict.uno")
+        """)
+        self.assertEqual(1, value)
+
+        value = BotlangSystem.run("""
+            (define a_dict (make-dict))
+            (define another_dict (make-dict))
+            (put! another_dict "uno" 1)
+            (put! another_dict "dos" 2)
+            (put! a_dict "another_dict" another_dict)
+            (get-or-nil a_dict "another_dict.tres")
+        """)
+        self.assertEqual(Nil, value)
+
+        value = BotlangSystem.run("""
+            (define a_list (list "hola" "como" "estas"))
+            (get a_list 2)
+        """)
+        self.assertEqual("estas", value)
+
+        value = BotlangSystem.run("""
+            (define a_list (list "hola" "como" "estas"))
+            (get-or-nil a_list 3)
+        """)
+        self.assertEqual(Nil, value)
+
+


### PR DESCRIPTION
Now get and get-or-nil are allowed to get variables in dicts like "dictOne.dictTwo.text"